### PR TITLE
Add Russian nav configuration for 4.x docs

### DIFF
--- a/4.x/ru/.config/nav-extra.yaml
+++ b/4.x/ru/.config/nav-extra.yaml
@@ -1,0 +1,31 @@
+"/ru/":
+-
+    title: Начало работы
+    icon: "/images/october-leaf.svg"
+    prefix: "/4.x/ru/"
+    link: "/4.x/ru/setup/installation.html"
+-
+    title: Руководство по CMS
+    icon: "/images/markup-guide.svg"
+    prefix: "/4.x/ru/cms/"
+    link: "/4.x/ru/cms/themes/themes.html"
+-
+    title: Фреймворк AJAX
+    icon: "/images/markup-guide.svg"
+    prefix: "/4.x/ru/ajax/"
+    link: "/4.x/ru/ajax/introduction.html"
+-
+    title: Руководство по разметке
+    icon: "/images/markup-guide.svg"
+    prefix: "/4.x/ru/markup/"
+    link: "/4.x/ru/markup/templating.html"
+-
+    title: Расширение October CMS
+    icon: "/images/markup-guide.svg"
+    prefix: "/4.x/ru/extend/"
+    link: "/4.x/ru/extend/system/plugins.html"
+-
+    title: Справочник API
+    icon: "/images/markup-guide.svg"
+    prefix: "/4.x/ru/element/"
+    link: "/4.x/ru/element/form-fields.html"

--- a/4.x/ru/.config/nav-main.yaml
+++ b/4.x/ru/.config/nav-main.yaml
@@ -1,0 +1,394 @@
+#
+# Elements Nav
+#
+"/ru/element/":
+-
+    title: Определения
+    children:
+        - form-fields
+        - list-columns
+        - filter-scopes
+        - inspector-types
+        - define-options
+        - available-icons
+-
+    title: Поля Tailor
+    children:
+        - content/field-mixin
+        - content/field-entries
+        - content/field-nesteditems
+-
+    title: Интерфейс формы
+    children:
+        - form/ui-section
+        - form/ui-hint
+        - form/ui-ruler
+        - form/ui-partial
+-
+    title: Поля формы
+    children:
+        - form/field-text
+        - form/field-number
+        - form/field-password
+        - form/field-email
+        - form/field-textarea
+        - form/field-dropdown
+        - form/field-radio
+        - form/field-balloon
+        - form/field-checkbox
+        - form/field-checkboxlist
+        - form/field-switch
+-
+    title: Виджеты формы
+    children:
+        - form/widget-codeeditor
+        - form/widget-colorpicker
+        - form/widget-datatable
+        - form/widget-datepicker
+        - form/widget-fileupload
+        - form/widget-markdown
+        - form/widget-mediafinder
+        - form/widget-nestedform
+        - form/widget-recordfinder
+        - form/widget-relation
+        - form/widget-repeater
+        - form/widget-richeditor
+        - form/widget-pagefinder
+        - form/widget-sensitive
+        - form/widget-taglist
+        - form/widget-currency
+        - form/widget-boxes
+-
+    title: Колонки списков
+    children:
+        - lists/column-text
+        - lists/column-number
+        - lists/column-image
+        - lists/column-switch
+        - lists/column-summary
+        - lists/column-datetime
+        - lists/column-selectable
+        - lists/column-linkage
+        - lists/column-partial
+        - lists/column-colorpicker
+        - lists/column-currency
+-
+    title: Области фильтра
+    children:
+        - filter/scope-checkbox
+        - filter/scope-switch
+        - filter/scope-text
+        - filter/scope-number
+        - filter/scope-dropdown
+        - filter/scope-group
+        - filter/scope-date
+-
+    title: Типы инспектора
+    children:
+        - inspector/type-string
+        - inspector/type-stringlist
+        - inspector/type-text
+        - inspector/type-autocomplete
+        - inspector/type-checkbox
+        - inspector/type-dropdown
+        - inspector/type-dictionary
+        - inspector/type-object
+        - inspector/type-objectlist
+        - inspector/type-set
+        # Types only supported by v3 Inspector
+        # - inspector/type-table
+        # - inspector/type-mediafinder
+
+#
+# Backend Nav
+#
+"/ru/extend/":
+-
+    title: Проектирование системы
+    children:
+        - system/plugins
+        - system/models
+        - system/controllers
+        - system/views
+        - system/behaviors
+        - system/widgets
+        - system/ajax
+-
+    title: Основные концепции
+    children:
+        - system/exceptions
+        - system/sending-mail
+        - system/localization
+        - system/routing
+        - system/scheduling
+        - system/unit-testing
+-
+    title: Расширение CMS
+    children:
+        - extending
+        - twig-tags
+        - tailor-fields
+        - cms-components
+        - console-commands
+-
+    title: Панель бэкенда
+    children:
+        - backend/navigation
+        - backend/users
+        - backend/permissions
+-
+    title: Проектирование форм
+    children:
+        - forms/form-controller
+        - forms/relation-controller
+        - forms/field-dependencies
+        - forms/form-widgets
+-
+    title: Проектирование списков
+    children:
+        - lists/list-controller
+        - lists/structures
+        - lists/filters
+        - lists/filter-widgets
+-
+    title: Импорт и экспорт
+    children:
+        - importexport/importexport-controller
+        - importexport/importexport-model
+-
+    title: Настройки и конфигурация
+    children:
+        - settings/settings
+        - settings/file-settings
+        - settings/model-settings
+-
+    title: Проектирование панели мониторинга
+    children:
+        - dashboards/dash-controller
+        - dashboards/data-sources
+        - dashboards/report-widgets
+        - dashboards/vue-report-widgets
+-
+    title: База данных
+    children:
+        - database/basics
+        - database/query
+        - database/model
+        - database/relations
+        - database/structure
+        - database/attachments
+        - database/collection
+        - database/pagination
+        - database/mutators
+        - database/serialization
+        - database/traits
+-
+    title: Службы
+    children:
+        - services/application
+        - services/cache
+        - services/collection
+        - services/log
+        - services/event
+        - services/html
+        - services/resizer
+        - services/http
+        - services/hash-crypt
+        - services/helpers
+        - services/parser
+        - services/queue
+        - services/request-input
+        - services/response-view
+        - services/session
+        - services/site
+        - services/storage
+        - services/validation
+-
+    title: Ресурсы
+    children:
+        - resources/publishing-packages
+        - resources/using-laravel-packages
+
+#
+# Markup Nav
+#
+"/ru/markup/":
+-
+    title: Разметка
+    collapsable: false
+    children:
+        - templating
+-
+    title: Свойства
+    collapsable: false
+    children:
+        - property/this-page
+        - property/this-layout
+        - property/this-theme
+        - property/this-param
+        - property/this-controller
+        - property/this-environment
+        - property/this-session
+        - property/this-request
+        - property/this-site
+-
+    title: Теги
+    collapsable: false
+    children:
+        - tag/page
+        - tag/partial
+        - tag/ajax-partial
+        - tag/content
+        - tag/component
+        - tag/placeholder
+        - tag/flash
+        - tag/cache
+        - tag/verbatim
+        - tag/macro
+        - tag/for
+        - tag/if
+-
+    title: Фильтры
+    collapsable: false
+    children:
+        - filter/app
+        - filter/page
+        - filter/link
+        - filter/theme
+        - filter/trans
+        - filter/media
+        - filter/resize
+        - filter/default
+        - filter/raw
+        - filter/md
+        - filter/currency
+-
+    title: Функции
+    collapsable: false
+    children:
+        - function/ajax-handler
+        - function/response
+        - function/redirect
+        - function/collect
+        - function/config
+        - function/carbon
+        - function/pager
+        - function/abort
+        - function/dump
+        - function/str
+        - function/form
+        - function/html
+
+#
+# Frontend Nav
+#
+"/ru/cms/":
+-
+    title: CMS
+    collapsable: false
+    children:
+        - themes/themes
+        - themes/pages
+        - themes/partials
+        - themes/layouts
+        - themes/content
+        - themes/components
+        - themes/snippets
+-
+    title: Tailor
+    collapsable: false
+    children:
+        - tailor/introduction
+        - tailor/blueprints
+        - tailor/content-fields
+        - tailor/navigation
+        - tailor/models
+-
+    title: Доступные компоненты
+    collapsable: false
+    children:
+        - components/section
+        - components/collection
+        - components/global
+        - components/resources
+        - components/sitepicker
+-
+    title: Разработка темы
+    collapsable: false
+    children:
+        - themes/settings
+        - themes/localization
+        - themes/child-themes
+        - themes/database-themes
+        - themes/seeding-themes
+-
+    title: Медиаменеджер
+    collapsable: false
+    children:
+        - media/introduction
+        - media/providers
+-
+    title: Ресурсы
+    collapsable: false
+    children:
+        - resources/multisite
+        - resources/building-apis
+
+#
+# AJAX Nav
+#
+"/ru/ajax/":
+-
+    title: AJAX
+    collapsable: false
+    children:
+        - introduction
+        - handlers
+        - update-partials
+        - attributes-api
+        - javascript-api
+        - turbo-router
+        - hot-controls
+-
+    title: Возможности
+    collapsable: false
+    children:
+        - features/validation
+        - features/uploads
+        - features/downloads
+        - features/loaders
+        - features/flash-messages
+        - features/pagination
+        - features/redirects
+        - features/polling
+        - features/modals
+
+#
+# Root Nav
+#
+"/ru/":
+-
+    title: Начало работы
+    collapsable: false
+    children:
+        - setup/installation
+        - setup/directory-structure
+        - setup/scheduler
+        - setup/deployment
+-
+    title: Конфигурация
+    collapsable: false
+    children:
+        - setup/configuration
+        - setup/web-server-config
+        - setup/database-config
+        - setup/mail-config
+        - setup/errors-logging
+-
+    title: Ресурсы
+    collapsable: false
+    children:
+        - resources/updating-october
+        - resources/installing-packages
+        - ['https://octobercms.com/docker-dev-image', 'Development Docker Image']
+        - resources/migrate-laravel-project


### PR DESCRIPTION
## Summary
- add Russian navigation configuration files for the 4.x documentation
- localize quick links to point to the Russian 4.x sections

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eec2a7166c8321b7b74a7fadaaab66